### PR TITLE
Item Edit Mode via  Detail View Controller

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		6D644AAA26F379EE00279CC2 /* UIImageCompressTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D644AA926F379EE00279CC2 /* UIImageCompressTest.swift */; };
 		6D644AAC26F6061C00279CC2 /* MarketDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D644AAB26F6061C00279CC2 /* MarketDetailViewController.swift */; };
 		6D644AB026F763AC00279CC2 /* MarketDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D644AAF26F763AC00279CC2 /* MarketDetailViewModel.swift */; };
+		6D644AB526FADAD900279CC2 /* Refreshable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D644AB426FADAD900279CC2 /* Refreshable.swift */; };
 		6D846D1026D75C8200349480 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D846D0F26D75C8200349480 /* AppDelegate.swift */; };
 		6D846D1226D75C8200349480 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D846D1126D75C8200349480 /* SceneDelegate.swift */; };
 		6D846D1926D75C8600349480 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D846D1826D75C8600349480 /* Assets.xcassets */; };
@@ -82,6 +83,7 @@
 		6D644AA926F379EE00279CC2 /* UIImageCompressTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageCompressTest.swift; sourceTree = "<group>"; };
 		6D644AAB26F6061C00279CC2 /* MarketDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketDetailViewController.swift; sourceTree = "<group>"; };
 		6D644AAF26F763AC00279CC2 /* MarketDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketDetailViewModel.swift; sourceTree = "<group>"; };
+		6D644AB426FADAD900279CC2 /* Refreshable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refreshable.swift; sourceTree = "<group>"; };
 		6D846D0C26D75C8200349480 /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D846D0F26D75C8200349480 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6D846D1126D75C8200349480 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -136,6 +138,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6D644AB126FADAA400279CC2 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				6D644AB426FADAD900279CC2 /* Refreshable.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		6D846D0326D75C8200349480 = {
 			isa = PBXGroup;
 			children = (
@@ -276,6 +286,7 @@
 		6D846D6C26DA045100349480 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				6D644AB126FADAA400279CC2 /* Protocol */,
 				6D846D8F26E5F0B200349480 /* Error */,
 				6D846D8A26E3D5AC00349480 /* Extension */,
 				6D846D6D26DA048400349480 /* MarketMainViewController.swift */,
@@ -487,6 +498,7 @@
 				6D846D7D26E0CEBC00349480 /* MarketImageCollectionViewHeader.swift in Sources */,
 				6D846D9126E5F11F00349480 /* MarketInputError.swift in Sources */,
 				6D644A9226ED145700279CC2 /* JSONEncoder+Extension.swift in Sources */,
+				6D644AB526FADAD900279CC2 /* Refreshable.swift in Sources */,
 				6D846D4B26D75F6800349480 /* ItemDelete.swift in Sources */,
 				6D846D6726D88AA600349480 /* MarketDecode.swift in Sources */,
 				6D644A8A26ECF29100279CC2 /* JSONDecoder+Extension.swift in Sources */,

--- a/OpenMarket/OpenMarket/Controllers/Extension/ViewController+Extension.swift
+++ b/OpenMarket/OpenMarket/Controllers/Extension/ViewController+Extension.swift
@@ -10,9 +10,11 @@ import UIKit
 extension UIViewController {
     typealias AlertActionHandler = ((UIAlertAction) -> Void)
     
-    func alert(title: String, message: String? = nil, okTitle: String = "OK") {
+    func alert(title: String, message: String? = nil, okTitle: String = "OK", completion: (() -> ())? = nil ) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let okAction = UIAlertAction(title: okTitle, style: .cancel)
+        let okAction = UIAlertAction(title: okTitle, style: .cancel) { _ in
+            completion?()
+        }
         alert.addAction(okAction)
     
         self.present(alert, animated: true)

--- a/OpenMarket/OpenMarket/Controllers/Extension/ViewController+Extension.swift
+++ b/OpenMarket/OpenMarket/Controllers/Extension/ViewController+Extension.swift
@@ -11,8 +11,21 @@ extension UIViewController {
     typealias AlertActionHandler = ((UIAlertAction) -> Void)
     
     func alert(title: String, message: String? = nil, okTitle: String = "OK") {
-        let alert: UIAlertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let okAction: UIAlertAction = UIAlertAction(title: okTitle, style: .cancel)
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: okTitle, style: .cancel)
+        alert.addAction(okAction)
+    
+        self.present(alert, animated: true)
+    }
+    
+    func alertCheck(title: String, message: String? = nil, okTitle: String = "OK", completion: @escaping () -> ()) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: okTitle, style: .destructive) { _ in
+            completion()
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        
+        alert.addAction(cancelAction)
         alert.addAction(okAction)
     
         self.present(alert, animated: true)

--- a/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
@@ -139,7 +139,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate 
                                              currency: currentItem.currency,
                                              stock: currentItem.stock,
                                              discountedPrice: currentItem.discountPrice,
-                                             images: currentItem.images,
+                                             images: self.marketDetailViewModel.getImageDatas(),
                                              password: password)
         
         return itemModifation

--- a/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
@@ -174,6 +174,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
             for index in 0..<self.marketDetailViewModel.getImageCount {
                 DispatchQueue.main.async {
                     let imageView = UIImageView()
+                    imageView.contentMode = .scaleAspectFit
                     let positionX = self.imageScrollView.frame.width * CGFloat(index)
                     let positionY = self.imageScrollView.frame.origin.y
                     imageView.frame = CGRect(x: positionX, y: positionY, width: self.imageScrollView.bounds.width, height: self.imageScrollView.bounds.height)

--- a/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
@@ -163,6 +163,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
                 self.convertStockFormat(stock: data.stock)
                 self.itemDescription.text = data.descriptions
                 self.itemTitle.text = data.title
+                self.loadViewIfNeeded()
             }
         }
     }
@@ -190,12 +191,13 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
     
     func setDetailViewController(item: Item) {
         guard let request = self.marketDetailViewModel.createRequestForItemFetch(item.id) else { return }
-        self.navigationItem.title = item.title
         self.marketDetailViewModel.fetch(request: request, decodeType: Item.self) { result in
             switch result {
             case .success(let judge):
                 if judge {
-                    // TODO: - 데이터 Fetch 성공후 어떠한 작업이 필요하다면 ...
+                    DispatchQueue.main.async {
+                        self.navigationItem.title = self.marketDetailViewModel.getDetailItem()?.title
+                    }
                 }
             case .failure(let error):
                 self.alert(title: MarketModelError.network(error).description)

--- a/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketDetailViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate {
+class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate, Refreshable {
     private let detailPageScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .white
@@ -71,6 +71,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate 
         return label
     }()
     private let marketDetailViewModel = MarketDetailViewModel()
+    lazy var marketRegisterAndEditViewController = MarketRegisterAndEditViewController()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -100,9 +101,8 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate 
                         switch result {
                         case .success(_):
                             DispatchQueue.main.async {
-                                let marketRegisterAndEditViewController = MarketRegisterAndEditViewController()
-                                marketRegisterAndEditViewController.setRegisterAndEditViewController(state: .edit, item: self.marketDetailViewModel.getDetailItem())
-                                self.navigationController?.pushViewController(marketRegisterAndEditViewController, animated: true)
+                                self.marketRegisterAndEditViewController.setRegisterAndEditViewController(state: .edit, item: self.marketDetailViewModel.getDetailItem())
+                                self.navigationController?.pushViewController(self.marketRegisterAndEditViewController, animated: true)
                             }
                         case .failure(_):
                             DispatchQueue.main.async {
@@ -147,6 +147,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate 
     
     private func setDelegate() {
         self.imageScrollView.delegate = self
+        self.marketRegisterAndEditViewController.refreshDelegate = self
     }
     
     private func setPageControlSelectedPage(currentPage: Int) {
@@ -200,6 +201,11 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate 
                 self.alert(title: MarketModelError.network(error).description)
             }
         }
+    }
+    
+    func refreshitem() {
+        guard let item = self.marketDetailViewModel.getDetailItem() else { return }
+        setDetailViewController(item: item)
     }
     
     private func convertPriceFormat(currency: String, price: UInt, discountPrice: UInt?) {

--- a/OpenMarket/OpenMarket/Controllers/MarketRegisterAndEditViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketRegisterAndEditViewController.swift
@@ -222,6 +222,29 @@ final class MarketRegisterAndEditViewController: UIViewController {
         }
     }
     
+    private func setKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    @objc func adjustForKeyboard(notification: Notification) {
+        guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+
+        let keyboardScreenEndFrame = keyboardValue.cgRectValue
+        let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
+
+        if notification.name == UIResponder.keyboardWillHideNotification {
+            itemDescription.contentInset = .zero
+        } else {
+            itemDescription.contentInset = UIEdgeInsets(top: 15, left: 10, bottom: keyboardViewEndFrame.height - view.safeAreaInsets.bottom, right: 10)
+        }
+
+        itemDescription.scrollIndicatorInsets = itemDescription.contentInset
+
+        let selectedRange = itemDescription.selectedRange
+        itemDescription.scrollRangeToVisible(selectedRange)
+    }
+    
     func setRegisterAndEditViewController(state: State, item: Item? = nil) {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(tappedFinishDoneButton))
         self.view.backgroundColor = .white

--- a/OpenMarket/OpenMarket/Controllers/MarketRegisterAndEditViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketRegisterAndEditViewController.swift
@@ -184,6 +184,12 @@ final class MarketRegisterAndEditViewController: UIViewController {
         setConstraints()
         setCurrencyTextField()
         setNotificationCenter()
+        setKeyboardObserver()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        self.view.endEditing(true)
     }
     
     private func setBindData() {

--- a/OpenMarket/OpenMarket/Controllers/MarketRegisterAndEditViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketRegisterAndEditViewController.swift
@@ -238,7 +238,7 @@ final class MarketRegisterAndEditViewController: UIViewController {
     }
     
     @objc private func tappedFinishDoneButton() {
-        if validItemInfomation(){
+        if validItemInfomation() {
             switch self.state {
             case .registration:
                 self.alertInputPassword { [weak self] password in
@@ -261,13 +261,15 @@ final class MarketRegisterAndEditViewController: UIViewController {
                         switch result {
                         case .success(_):
                             DispatchQueue.main.async {
-                                self?.alert(title: "수정이 완료되었습니다") { 
+                                self?.alert(title: "수정이 완료되었습니다") {
+                                    self?.refreshDelegate?.refreshitem()
                                     self?.navigationController?.popViewController(animated: true)
                                 }
-                                self?.refreshDelegate?.refreshitem()
                             }
                         case .failure(_) :
-                            return
+                            DispatchQueue.main.async {
+                                self?.alert(title: "비밀번호를 확인해주세요.")
+                            }
                         }
                     })
                 }
@@ -324,27 +326,27 @@ final class MarketRegisterAndEditViewController: UIViewController {
     }
     
     private func validItemInfomation() -> Bool {
-        guard let _ = self.itemTitle.text else {
+        guard let title = self.itemTitle.text, title.count >= 1 else {
             self.alert(title: MarketInputError.title.rawValue)
             return false
         }
         
-        guard let _ = self.itemCurrency.text else {
+        guard let currency = self.itemCurrency.text, currency.count >= 1 else {
             self.alert(title: MarketInputError.currency.rawValue)
             return false
         }
         
-        guard let _ = self.itemPrice.text else {
+        guard let price = self.itemPrice.text, price.count >= 1 else {
             self.alert(title: MarketInputError.price.rawValue)
             return false
         }
         
-        guard let _ = self.itemStock.text else {
+        guard let stock = self.itemStock.text, stock.count >= 1 else {
             self.alert(title: MarketInputError.stock.rawValue)
             return false
         }
         
-        guard let _ = self.itemDescription.text else {
+        guard let descriptions = self.itemDescription.text, descriptions.count >= 1 else {
             self.alert(title: MarketInputError.description.rawValue)
             return false
         }
@@ -558,30 +560,32 @@ extension MarketRegisterAndEditViewController: UIPickerViewDelegate {
 
 extension MarketRegisterAndEditViewController: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        
         switch textField.accessibilityIdentifier {
         case Identifier.itemTitle:
             self.itemInfomation.title = textField.text
         case Identifier.itemPrice:
-            guard let _ = Int(textField.text ?? "") else {
+            guard let _ = Int(text) else {
                 self.alert(title: MarketInputError.priceType.rawValue)
                 self.itemPrice.text = nil
                 return
             }
             self.itemInfomation.price = textField.text
         case Identifier.itemDiscountPrice:
-            guard let _ = Int(textField.text ?? "") else {
+            guard let _ = Int(text) else {
                 self.alert(title: MarketInputError.discountPriceType.rawValue)
                 self.itemDiscountPrice.text = nil
                 return
             }
             self.itemInfomation.discountPrice = textField.text
         case Identifier.itemStock:
-            guard let _ = Int(textField.text ?? "") else {
+            guard let _ = Int(text) else {
                 self.alert(title: MarketInputError.stockType.rawValue)
                 self.itemStock.text = nil
                 return
             }
-            self.itemInfomation.stock = textField.text
+            self.itemInfomation.stock = text
         default:
             return
         }

--- a/OpenMarket/OpenMarket/Controllers/Protocol/Refreshable.swift
+++ b/OpenMarket/OpenMarket/Controllers/Protocol/Refreshable.swift
@@ -1,0 +1,12 @@
+//
+//  Refreshable.swift
+//  OpenMarket
+//
+//  Created by Fezravien on 2021/09/22.
+//
+
+import Foundation
+
+protocol Refreshable: NSObject {
+    func refreshitem()
+}

--- a/OpenMarket/OpenMarket/Models/Network/NetworkManager.swift
+++ b/OpenMarket/OpenMarket/Models/Network/NetworkManager.swift
@@ -35,14 +35,15 @@ final class NetworkManager {
         }
     }
     
-    func excutePost(request: URLRequest, completion: @escaping (Error) -> Void) {
+    func excutePost(request: URLRequest, completion: @escaping (Result<Bool,Error>) -> Void) {
         self.loader.excuteNetwork(request: request) { result in
             switch result {
             case .success(let data):
                 // TODO: - POST 후 받은 것을 가지고 다른 기능 구현가능
                 guard let _ = data else { return }
+                completion(.success(true))
             case .failure(let error):
-                completion(MarketModelError.request(error))
+                completion(.failure(MarketModelError.request(error)))
             }
         }
     }
@@ -63,7 +64,7 @@ final class NetworkManager {
         return request
     }
     
-    /// POST, PATCH - Mulit-part/Form-data
+    /// DELETE - JSONEncoder
     func createRequest<T: Encodable>(data: T, itemID: Int) throws -> URLRequest? {
         let encodeData: Data
         
@@ -81,7 +82,7 @@ final class NetworkManager {
         return request
     }
     
-    /// DELETE - JSONEncoder
+    /// POST, PATCH - Mulit-part/Form-data
     func createRequest<T: MultiPartForm>(url: URL?, encodeType: T, method: NetworkConstant.Method) throws -> URLRequest {
         guard let url = url else { throw MarketModelError.url }
             

--- a/OpenMarket/OpenMarket/Models/Request/ItemModifaction.swift
+++ b/OpenMarket/OpenMarket/Models/Request/ItemModifaction.swift
@@ -12,8 +12,8 @@ struct ItemModifcation: MultiPartForm {
     let descriptions: String?
     let price: UInt?
     let currency: String?
-    let stock: UInt32?
+    let stock: UInt?
     let discountedPrice: UInt?
-    let images: [Data]?
+    let images: [String]?
     let password: String
 }

--- a/OpenMarket/OpenMarket/Models/Request/ItemModifaction.swift
+++ b/OpenMarket/OpenMarket/Models/Request/ItemModifaction.swift
@@ -14,6 +14,6 @@ struct ItemModifcation: MultiPartForm {
     let currency: String?
     let stock: UInt?
     let discountedPrice: UInt?
-    let images: [String]?
+    let images: [Data]?
     let password: String
 }

--- a/OpenMarket/OpenMarket/ViewModel/MarketDetailViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModel/MarketDetailViewModel.swift
@@ -34,9 +34,18 @@ final class MarketDetailViewModel {
         return self.detailItem
     }
     
-    func createRequest(_ id: UInt) -> URLRequest? {
+    func createRequestForItemFetch(_ id: UInt) -> URLRequest? {
         let request = self.networkManager.createRequest(id: id)
         return request
+    }
+    
+    func createRequestForItemPatch(id: UInt, item: ItemModifcation) throws -> URLRequest? {
+        do {
+            let request = try self.networkManager.createRequest(url: NetworkConstant.edit(id: id).url ?? URL(string: ""), encodeType: item, method: .patch)
+            return request
+        } catch {
+            return nil
+        }
     }
     
     func fetch<T>(request: URLRequest, decodeType: T.Type, completion: @escaping (Result<Bool, Error>) -> Void) where T: Decodable {
@@ -49,6 +58,17 @@ final class MarketDetailViewModel {
                 completion(.success(true))
             case .failure(let error):
                 completion(.failure(error))
+            }
+        }
+    }
+    
+    func patch(request: URLRequest, completion: @escaping (Result<Bool,Error>) -> Void) {
+        self.networkManager.excutePost(request: request) { result in
+            switch result {
+            case .success(_):
+                completion(.success(true))
+            case .failure(_):
+                completion(.failure(MarketModelError.patch))
             }
         }
     }

--- a/OpenMarket/OpenMarket/ViewModel/MarketDetailViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModel/MarketDetailViewModel.swift
@@ -30,6 +30,10 @@ final class MarketDetailViewModel {
         return self.itemImages[index]
     }
     
+    func getImageDatas() -> [Data] {
+        return self.itemImages
+    }
+    
     func getDetailItem() -> Item? {
         return self.detailItem
     }

--- a/OpenMarket/OpenMarket/ViewModel/MarketRegisterAndEditViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModel/MarketRegisterAndEditViewModel.swift
@@ -9,35 +9,55 @@ import UIKit
 
 final class MarketRegisterAndEditViewModel {
     var imageChanged: () -> () = { }
+    var editItemChanged: () -> () = { }
     private let networkManager = NetworkManager(loader: MarketNetwork(session: URLSession.shared), decoder: JSONDecoder(), encoder: JSONEncoder())
-    private var itemImage: [UIImage] = [] {
+    private var itemImages: [UIImage] = [] {
         didSet {
             self.imageChanged()
         }
     }
+    private var editItem: Item? {
+        didSet {
+            self.editItemChanged()
+        }
+    }
     
-    var itemImageCount: Int { itemImage.count }
+    var itemImageCount: Int { itemImages.count }
+    
+    func setEditItem(item: Item?) {
+        guard let item = item else { return }
+        self.editItem = item
+    }
+    
+    func getEditItem() -> Item? {
+        guard let item = self.editItem else { return nil }
+        return item
+    }
     
     func getItemImage(index: Int) -> UIImage {
-        return self.itemImage[index]
+        return self.itemImages[index]
     }
     
     func getItemImages() -> [Data] {
         var imageData: [Data] = []
-        for image in itemImage {
+        for image in itemImages {
             imageData.append(image.compress() ?? Data())
         }
         return imageData
     }
     
     func appendItemImage(_ image: UIImage) {
-        self.itemImage.append(image)
+        self.itemImages.append(image)
+    }
+    
+    func removeItemImage(index: Int) {
+        self.itemImages.remove(at: index)
     }
     
     func createRequest<T: MultiPartForm>(url: URL?, type: T, method: NetworkConstant.Method) throws -> URLRequest? {
         let request: URLRequest
         do {
-            request = try self.networkManager.createRequest(url: url, encodeType: type, method: .post)
+            request = try self.networkManager.createRequest(url: url, encodeType: type, method: method)
         } catch {
             throw MarketModelError.createRequest
         }
@@ -58,5 +78,24 @@ final class MarketRegisterAndEditViewModel {
     
     func patch() {
         
+    }
+    
+    func downloadImage(imageURL: [String]) {
+        var images: [UIImage] = []
+        if imageURL.isEmpty { return }
+        for index in 0..<imageURL.count {
+            guard let url = URL(string: imageURL[index]) else { return }
+            
+            DispatchQueue.global(qos: .background).async {
+                if let image = try? Data(contentsOf: url) {
+                    DispatchQueue.main.async {
+                        images.append(UIImage(data: image) ?? UIImage())
+                        if images.count == imageURL.count {
+                            self.itemImages = images
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/OpenMarket/OpenMarket/ViewModel/MarketRegisterAndEditViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModel/MarketRegisterAndEditViewModel.swift
@@ -65,8 +65,8 @@ final class MarketRegisterAndEditViewModel {
         return request
     }
     
-    func post<T>(request: URLRequest, decodeType: T.Type, completion: @escaping (Result<Bool, Error>) -> Void) where T: Decodable {
-        self.networkManager.excuteFetch(request: request, decodeType: decodeType) { result in
+    func post(request: URLRequest, completion: @escaping (Result<Bool, Error>) -> Void) {
+        self.networkManager.excutePost(request: request) { result in
             switch result {
             case .success(_):
                 completion(.success(true))
@@ -75,11 +75,7 @@ final class MarketRegisterAndEditViewModel {
             }
         }
     }
-    
-    func patch() {
-        
-    }
-    
+
     func downloadImage(imageURL: [String]) {
         var images: [UIImage] = []
         if imageURL.isEmpty { return }

--- a/OpenMarket/OpenMarket/Views/RegisterAndEdit/MarketImageCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Views/RegisterAndEdit/MarketImageCollectionViewCell.swift
@@ -20,7 +20,6 @@ final class MarketImageCollectionViewCell: UICollectionViewCell {
     
     func configurateImageCell(image: UIImage) {
         setItemImageViewConstraint()
-        self.backgroundColor = .systemOrange
         self.itemImageView.image = image
     }
     


### PR DESCRIPTION
### 기능 구현 

상세 페이지의 `Action Sheet`를 통한 상품 수정 모드
- 비밀번호 체크 
    - 틀린다면 오류 알림
- 상품 등록/수정 페이지로 이동 후 수정 모드로 제품 수정
    - 제목, 가격, 할인 가격, 수량, 상세 설명
    - 상세 설명 입력 과정의 커서의 위치에 따른 스크롤 수정 기능 추가 
- 수정이 끝난 후 비밀번호 재 체크 
- 정상적으로 서버에 수정이 완료
    - 수정완료 알림창 
    - 제품 상세 페이지로 이동 후 수정된 상품 새로고침 