### PR TITLE
Image Cache 

### DIFF
--- a/OpenMarket/OpenMarket/Controllers/MarketMainViewController.swift
+++ b/OpenMarket/OpenMarket/Controllers/MarketMainViewController.swift
@@ -177,13 +177,19 @@ extension MarketMainViewController: UICollectionViewDataSource {
         switch self.marketSegmentController.selectedSegmentIndex {
         case 0:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MarketListCollectionViewCell.identifier, for: indexPath) as? MarketListCollectionViewCell else { return UICollectionViewCell() }
-            
-            cell.configurateListCell(data: marketViewModel.getMarketItem(index: indexPath.row))
+            let item = self.marketViewModel.getMarketItem(index: indexPath.row)
+            self.marketViewModel.downloadImage(item.thumbnails.first ?? "") { imageData in
+                cell.configurateListCellImage(imageData: imageData)
+            }
+            cell.configurateListCellText(data: self.marketViewModel.getMarketItem(index: indexPath.row))
             return cell
         case 1:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MarketGridCollectionViewCell.identifier, for: indexPath) as? MarketGridCollectionViewCell else { return UICollectionViewCell() }
-            
-            cell.configurateGridCell(data: marketViewModel.getMarketItem(index: indexPath.row))
+            let item = self.marketViewModel.getMarketItem(index: indexPath.row)
+            self.marketViewModel.downloadImage(item.thumbnails.first ?? "") { imageData in
+                cell.configurateGridCellImage(imageData: imageData)
+            }
+            cell.configurateGridCellText(data: self.marketViewModel.getMarketItem(index: indexPath.row))
             return cell
         default:
             return UICollectionViewCell()

--- a/OpenMarket/OpenMarket/Views/Main/MarketGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Views/Main/MarketGridCollectionViewCell.swift
@@ -75,7 +75,7 @@ class MarketGridCollectionViewCell: UICollectionViewCell {
         return label
     }()
 
-    func configurateGridCell(data: Item) {
+    func configurateGridCellText(data: Item) {
         self.contentView.layer.borderWidth = 2
         self.contentView.layer.cornerRadius = 15
         setConstraints()
@@ -83,6 +83,12 @@ class MarketGridCollectionViewCell: UICollectionViewCell {
         convertStockFormat(stock: data.stock)
         downloadImage(data.thumbnails.first!)
         self.itemTitle.text = data.title
+    }
+    
+    func configurateGridCellImage(imageData: Data?) {
+        DispatchQueue.main.async {
+            self.itemImageView.image = UIImage(data: imageData ?? Data())
+        }
     }
     
     override func prepareForReuse() {

--- a/OpenMarket/OpenMarket/Views/Main/MarketListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Views/Main/MarketListCollectionViewCell.swift
@@ -71,12 +71,19 @@ final class MarketListCollectionViewCell: UICollectionViewCell {
         return label
     }()
 
-    func configurateListCell(data: Item) {
-        setConstraints()
-        convertPriceFormat(currency: data.currency, price: data.price, discountPrice: data.discountPrice)
-        convertStockFormat(stock: data.stock)
-        downloadImage(data.thumbnails.first!)
-        self.itemTitle.text = data.title
+    func configurateListCellText(data: Item) {
+        DispatchQueue.main.async {
+            self.setConstraints()
+            self.convertPriceFormat(currency: data.currency, price: data.price, discountPrice: data.discountPrice)
+            self.convertStockFormat(stock: data.stock)
+            self.itemTitle.text = data.title
+        }
+    }
+    
+    func configurateListCellImage(imageData: Data?) {
+        DispatchQueue.main.async {
+            self.itemImageView.image = UIImage(data: imageData ?? Data())
+        }
     }
     
     override func prepareForReuse() {
@@ -105,16 +112,16 @@ final class MarketListCollectionViewCell: UICollectionViewCell {
         self.itemStock.textColor = .systemGray
     }
     
-    private func downloadImage(_ imageURL: String) {
-        guard let url = URL(string: imageURL) else { return }
-        DispatchQueue.global(qos: .background).async {
-            if let image = try? Data(contentsOf: url) {
-                DispatchQueue.main.async {
-                    self.itemImageView.image = UIImage(data: image)
-                }
-            }
-        }
-    }
+//    private func downloadImage(_ imageURL: String) {
+//        guard let url = URL(string: imageURL) else { return }
+//        DispatchQueue.global(qos: .background).async {
+//            if let image = try? Data(contentsOf: url) {
+//                DispatchQueue.main.async {
+//                    self.itemImageView.image = UIImage(data: image)
+//                }
+//            }
+//        }
+//    }
     
     private func convertStockFormat(stock: UInt) {
         if stock == 0 {


### PR DESCRIPTION
### 구현 내용

- Image Cache 기능추가
    - 로딩 후 이미 다운 받았던 이미지는 다시 받지않고 캐시를 통해 바로바로 업데이트 가능
    - 이미지 다운로드를 재활용하면서 한층 더 쾌적한 앱이 되었다.
    - 메인 페이지에만  Image Cache를 적용한 이유
        - 상세 페이지를 유저가 본 것을 지속적으로 누를 확률이 적음 (한번 보고 그만!) 
        - 메인 페이지 처럼 재사용으로 인한 버벅임과 같은 불편함이 없음
    
- 이미지 다운로드(네트워크) ViewModel로 로직 이동
    - MVVM 아키텍처를 따르기 위해서 View는 멍청하게 하도록하자 -> 네트워크 로직은 `ViewModel`

- MVVM 아키텍처에서 유저의 이벤트를 받는다면?
    - 모델을 변경시키는 유저의 이벤트 인가?
        - 변경 O : ViewModel을 통해 Model을 변경시키고 DataBinding을 통해 View에 보낸다
        - 변경 X : ViewController에서 간단하게 로직으로 처리 