### PR TITLE
상품 등록 페이지 및 등록 후 처리 리팩토링 

### DIFF
--- a/OpenMarket/OpenMarket/ViewModels/MarketDetailViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/MarketDetailViewModel.swift
@@ -94,12 +94,12 @@ final class MarketDetailViewModel {
     }
     
     private func downloadImage(imageURL: [String]) {
-        //        let imageDispatchGroup = DispatchGroup()
         let imageDispatchQueue = DispatchQueue(label: "시리얼 이미지 다운로드 큐")
         var images: [Data] = []
         if imageURL.isEmpty { return }
         for index in 0..<imageURL.count {
             guard let url = URL(string: imageURL[index]) else { return }
+            
             imageDispatchQueue.sync {
                 if let image = try? Data(contentsOf: url) {
                     images.append(image)

--- a/OpenMarket/OpenMarket/ViewModels/MarketDetailViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/MarketDetailViewModel.swift
@@ -31,8 +31,8 @@ final class MarketDetailViewModel {
     // MARK: - Detial View: Model change due to the user's event.
     
     func refreshItem(item: Item) {
-        downloadImage(imageURL: item.images ?? [])
         self.detailItem = item
+        downloadImage(imageURL: item.images ?? [])
     }
     
     // MARK: - Convert Format
@@ -94,19 +94,19 @@ final class MarketDetailViewModel {
     }
     
     private func downloadImage(imageURL: [String]) {
+        //        let imageDispatchGroup = DispatchGroup()
+        let imageDispatchQueue = DispatchQueue(label: "시리얼 이미지 다운로드 큐")
         var images: [Data] = []
         if imageURL.isEmpty { return }
         for index in 0..<imageURL.count {
             guard let url = URL(string: imageURL[index]) else { return }
-            
-            DispatchQueue.global(qos: .background).async {
+            imageDispatchQueue.sync {
                 if let image = try? Data(contentsOf: url) {
                     images.append(image)
-                    if images.count == imageURL.count {
-                        self.itemImages = images
-                    }
                 }
             }
         }
+     
+        self.itemImages = images
     }
 }

--- a/OpenMarket/OpenMarket/ViewModels/MarketRegisterAndEditViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/MarketRegisterAndEditViewModel.swift
@@ -167,19 +167,21 @@ final class MarketRegisterAndEditViewModel {
             }
         }
     }
-
+    
     func downloadImage(imageURL: [String]) {
+        let dispatchSerialQueue = DispatchQueue(label: "이미지 다운로드 시리얼 큐")
         var images: [UIImage] = []
         if imageURL.isEmpty { return }
-        for index in 0..<imageURL.count {
-            guard let url = URL(string: imageURL[index]) else { return }
-            
-            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2) {
-                if let image = try? Data(contentsOf: url) {
-                    DispatchQueue.main.async {
-                        images.append(UIImage(data: image) ?? UIImage())
-                        if images.count == imageURL.count {
-                            self.itemImages = images
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
+            for index in 0..<imageURL.count {
+                guard let url = URL(string: imageURL[index]) else { return }
+                dispatchSerialQueue.sync {
+                    if let image = try? Data(contentsOf: url) {
+                        DispatchQueue.main.async {
+                            images.append(UIImage(data: image) ?? UIImage())
+                            if images.count == imageURL.count {
+                                self.itemImages = images
+                            }
                         }
                     }
                 }

--- a/OpenMarket/OpenMarket/Views/DetailPage/MarketDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Views/DetailPage/MarketDetailViewController.swift
@@ -88,7 +88,6 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
     private var displayMode: DetailPageMode = .editAndDelete
     private var registeredItem: Item?
     weak var updateDelegate: MainSceneDelegate?
-    lazy var marketRegisterAndEditViewController = MarketRegisterAndEditViewController()
     
     // MARK: - View life cycle
     
@@ -166,7 +165,6 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
     
     private func setDelegate() {
         self.imageScrollView.delegate = self
-        self.marketRegisterAndEditViewController.modificationDelegate = self
     }
     
     // MARK: - Set self Navigation
@@ -227,8 +225,11 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
                     
                     DispatchQueue.main.async {
                         self.indicater.stopAnimating()
-                        self.marketRegisterAndEditViewController.setRegisterAndEditViewController(state: .edit, item: item)
-                        self.navigationController?.pushViewController(self.marketRegisterAndEditViewController, animated: true)
+                        let marketRegisterAndEditViewController = MarketRegisterAndEditViewController()
+                        self.navigationController?.pushViewController(marketRegisterAndEditViewController, animated: true)
+                        marketRegisterAndEditViewController.setRegisterAndEditViewController(state: .edit, item: item)
+                        marketRegisterAndEditViewController.modificationDelegate = self
+                        
                     }
                 }
             }

--- a/OpenMarket/OpenMarket/Views/DetailPage/MarketDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Views/DetailPage/MarketDetailViewController.swift
@@ -9,6 +9,11 @@ import UIKit
 
 class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate, DetailSceneDelegate {
     
+    private enum DetailPageMode {
+        case editAndDelete
+        case registered
+    }
+    
     // MARK: - variable, constant and UI Initialization
     
     private let detailPageScrollView: UIScrollView = {
@@ -80,6 +85,8 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
         return indicater
     }()
     private let marketDetailViewModel = MarketDetailViewModel()
+    private var displayMode: DetailPageMode = .editAndDelete
+    private var registeredItem: Item?
     weak var updateDelegate: MainSceneDelegate?
     lazy var marketRegisterAndEditViewController = MarketRegisterAndEditViewController()
     
@@ -91,6 +98,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
         addNavigationItem()
         setDelegate()
         bindData()
+        setRegisteredItem()
     }
     
     // MARK: - Data binding with ViewModel (DetailViewModel)
@@ -106,6 +114,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
             DispatchQueue.main.async {
                 self?.updateItemText(item: item)
                 self?.updateImage(image: image)
+                self?.view.layoutIfNeeded()
             }
         }
     }
@@ -256,7 +265,7 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
         return itemModifation
     }
     
-    // MARK: - Receive data from MainViewController
+    // MARK: - Receive data from otherViewController
     
     func setDetailViewController(item: Item) {
         guard let request = self.marketDetailViewModel.createRequestForItemFetch(item.id) else { return }
@@ -266,6 +275,22 @@ class MarketDetailViewController: UIViewController, UIGestureRecognizerDelegate,
         }
     }
     
+    func displayRegisteredItem(item: Item) {
+        self.displayMode = .registered
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(tappedCloseButton))
+        self.registeredItem = item
+    }
+    
+    private func setRegisteredItem() {
+        guard let item = self.registeredItem else { return }
+        refreshDetailItem(item: item)
+    }
+    
+    @objc private func tappedCloseButton() {
+        self.navigationController?.popToRootViewController(animated: true)
+        self.updateDelegate?.refreshMainItemList()
+    }
+
     // MARK: - Delegate Pattern from other View or ViewController
     
     func refreshDetailItem(item: Item) {

--- a/OpenMarket/OpenMarket/Views/MainPage/ViewController/MarketMainViewController.swift
+++ b/OpenMarket/OpenMarket/Views/MainPage/ViewController/MarketMainViewController.swift
@@ -177,15 +177,6 @@ final class MarketMainViewController: UIViewController, MainSceneDelegate {
         self.marketMainViewModel.removeAllItems()
     }
     
-    func displayRegisteratedItem(item: Item) {
-        self.marketDetailViewController = MarketDetailViewController()
-        self.navigationController?.pushViewController(self.marketDetailViewController ?? MarketDetailViewController(), animated: true)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [unowned self] in
-            self.itemListCollectionView.reloadData()
-            self.marketDetailViewController?.refreshDetailItem(item: item)
-        }
-    }
-    
     func stopIndicater() {
         if self.itemListLoadingindicater.isAnimating {
             self.itemListLoadingindicater.stopAnimating()

--- a/OpenMarket/OpenMarket/Views/Protocols/MainSceneDelegate.swift
+++ b/OpenMarket/OpenMarket/Views/Protocols/MainSceneDelegate.swift
@@ -9,6 +9,5 @@ import Foundation
 
 protocol MainSceneDelegate: AnyObject {
     func stopIndicater()
-    func displayRegisteratedItem(item: Item)
     func refreshMainItemList()
 }

--- a/OpenMarket/OpenMarket/Views/RegisterAndEditPage/View/MarketImageCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Views/RegisterAndEditPage/View/MarketImageCollectionViewCell.swift
@@ -14,6 +14,7 @@ final class MarketImageCollectionViewCell: UICollectionViewCell {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
+        imageView.backgroundColor = .darkGray
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()

--- a/OpenMarket/OpenMarket/Views/RegisterAndEditPage/ViewController/MarketRegisterAndEditViewController.swift
+++ b/OpenMarket/OpenMarket/Views/RegisterAndEditPage/ViewController/MarketRegisterAndEditViewController.swift
@@ -214,9 +214,10 @@ final class MarketRegisterAndEditViewController: UIViewController {
         
         self.marketRegisterAndEditViewModel.bindItemForEdit { [weak self] item in
             guard let item = item else { return }
+            self?.marketRegisterAndEditViewModel.downloadImage(imageURL: item.images ?? [])
+            
             DispatchQueue.main.async {
                 self?.navigationItem.title = item.title
-                self?.marketRegisterAndEditViewModel.downloadImage(imageURL: item.images ?? [])
                 self?.itemTitle.text = item.title
                 self?.itemCurrency.text = item.currency
                 self?.itemPrice.text = String(item.price)
@@ -288,7 +289,7 @@ final class MarketRegisterAndEditViewController: UIViewController {
         itemDescription.scrollRangeToVisible(selectedRange)
     }
     
-    // MARK: - Receive data from MainViewController
+    // MARK: - Receive data from MainViewController or DetailViewController
     
     func setRegisterAndEditViewController(state: State, item: Item? = nil) {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(tappedFinishDoneButton))

--- a/OpenMarket/OpenMarket/Views/RegisterAndEditPage/ViewController/MarketRegisterAndEditViewController.swift
+++ b/OpenMarket/OpenMarket/Views/RegisterAndEditPage/ViewController/MarketRegisterAndEditViewController.swift
@@ -322,8 +322,9 @@ final class MarketRegisterAndEditViewController: UIViewController {
                         DispatchQueue.main.async {
                             self?.indicater.stopAnimating()
                             self?.alert(title: "등록이 완료되었습니다") {
-                                self?.registrationDelegate?.displayRegisteratedItem(item: item)
-                                self?.navigationController?.popViewController(animated: true)
+                                let detailViewController = MarketDetailViewController()
+                                self?.navigationController?.pushViewController(detailViewController, animated: true)
+                                detailViewController.displayRegisteredItem(item: item)
                             }
                         }
                     })


### PR DESCRIPTION
### 상품 등록, 수정 페이지에 상품 수정으로 진입했을 때 이미지가 보이지 않는 문제

#### 트러블

사용자가 등록한 상품을 수정하기 위해 `상품 상세 페이지`의 `Action Sheet`를 통해 `상품 수정 페이지`로 이동하게 된다.
`상품 수정 페이지`에는 이미지, 제목, 화폐, 가격, 할인 가격(옵셔널), 수량, 상세 정보가 기존의 정보로 채워져 있어야 하지만, 
처음 앱을 구동했을 때 최초의 등록화면에 진입하면 이미지가 보여지는 것을 볼 수 있지만, 그 이후에 동일한 작업을 하게되면 이미지가 없는 현상이 생겼다.

<img src="https://raw.githubusercontent.com/Fezravien/UploadForMarkdown/forUpload/img/Simulator%20Screen%20Recording%20-%20iPhone%2012%20Pro%20Max%20-%202021-10-19%20at%2013.08.41.gif" alt="Simulator Screen Recording - iPhone 12 Pro Max - 2021-10-19 at 13.08.41" width="30%" /> <img src="https://images.velog.io/images/fezravien/post/01e27727-7162-4aa0-8aca-130fb2801d83/Simulator%20Screen%20Recording%20-%20iPhone%2012%20Pro%20Max%20-%202021-10-19%20at%2011.55.47-46(%EB%93%9C%EB%9E%98%EA%B7%B8%ED%95%A8).tiff" width="30%;" />

<br>

#### 문제 인식

##### 추측

1. 서버에 등록된 이미지를 가져오는 것(네트워크)에 딜레이로 인해 이미지가 업데이트 되지 못했다.
2. 서버에 이미지가 AWS 서버에 등록되는 시점과 이미지를 화면에 띄워주는 시점이 맞지 않았다.
3. ViewController가 생성되어 메모리에 올라오기 전에 데이터를 업데이트 시켜줬다. (MVVM 이키텍처 - Model의 변화로 ViewModel과 View간의 바인딩을 통해 업데이트를 한다.)

<br>

#### 해결

상품 수정 페이지에서 이미지를 다운로드 할 때 `DispatchQueue.main.asyncAfter`를 통해 딜레이를 시켜서 해결할 수 있었다.

```swift
    func downloadImage(imageURL: [String]) {
        var images: [UIImage] = []
        if imageURL.isEmpty { return }
        for index in 0..<imageURL.count {
            guard let url = URL(string: imageURL[index]) else { return }
            
            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2) {
                if let image = try? Data(contentsOf: url) {
                    DispatchQueue.main.async {
                        images.append(UIImage(data: image) ?? UIImage())
                        if images.count == imageURL.count {
                            self.itemImages = images
                        }
                    }
                }
            }
        }
```

하지만 이미지의 갯수에 따라 동작하지 않는 상황이 존재했다. 딜레이를 1초로 주고 이미지가 5개가 존재한다면, 똑같이 이미지가 반영되지 않는 모습이 보였다. 다만 2초에 딜레이를 둔다면 5개도 동작이 정상정으로 수행됨을 알 수 있었다,

딜레이를 넉넉하게 줌으로써 기능이 동작하도록 했지만, 왜 딜레이를 줘야 기능이 정상적으로 작동하는 것인지 조금 더 디버깅을 구체적으로 해보면서 생각해보았다.

![스크린샷 2021-10-19 오후 10.11.38](https://raw.githubusercontent.com/Fezravien/UploadForMarkdown/forUpload/img/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202021-10-19%20%E1%84%8B%E1%85%A9%E1%84%92%E1%85%AE%2010.11.38.png)

위의 그림처럼 서버에 비밀번호를 확인하기 위해 `PATCH` 요청을 보내게 되면 동일한 이미지를 가지고 있지만 AWS 서버에는 다른 URL로 저장되게 되는데, 이때 딜레이를 주지 않고 이미지를 다운로드하게되면 기존의 이미지 URL로 요청하게 되서 처음에는 이미지가 보여지겠지만, 두 번째 동일한 동작을 하게되면 이미지 URL이 바뀌었기 때문에 서버로부터 이미지를 불러올 수 없게된다. 

그래서 딜레이를 주게되면 서버에 비밀번호 요청과 함께 (이미지는 동일하지만) 수정되는 사항을 동기화 시킬 시간을 주게되어 이미지가 동일한 동작에도 보여질 수 있게된다.

<br>

#### 개선

비빌번호 검증으로 인한 `PATCH` 요청은 어쩔 수 없는 부분인 것 같다. 이 부분은 서버와 협업을 통해 비밀번호만 검증할 수 있도록 API를 구현해달라고 요청해야 원활하게 처리할 수 있을 것 같다. 

이 부분에서 개선해보고 싶은 부분은 딜레이를 효율적으로 사용하는 것이다.

기존의 해결방식인 `동시큐`, `비동기 작업`이다. 이미지의 순서를 고려하지 않는다.

```swift
DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2) {
    if let image = try? Data(contentsOf: url) {
        DispatchQueue.main.async {
            images.append(UIImage(data: image) ?? UIImage())
            if images.count == imageURL.count {
                self.itemImages = images
            }
        }
    }
}
```

![스크린샷 2021-10-20 오전 12.49.24](https://raw.githubusercontent.com/Fezravien/UploadForMarkdown/forUpload/img/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202021-10-20%20%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%A5%E1%86%AB%2012.49.24.png)

<br>

기존의 방식에서 이미지의 순서를 고려하고, 불필요할 수도 있는 딜레이를 하지 않기 위해 개선했다.
`CustomQueue`를 사용하여 **시리얼 큐를 통한 동기적 작업**으로 이미지의 순서를 보장했고, 딜레이를 이미지 전체에 한번만 줘서 **기존에 불필요 할 수 있었던 딜레이를 줄였다.**

작업을 보장하게 할 수 있는 방법은 여러가지가 존재한다.

1. `Custom Queue` 

   커스텀 큐는 **디폴트는 시리얼 큐**이며 동시큐로 만들 수도 있다.

   현재 이슈에서 이미지의 순서를 보장하기 위해 사용했다.

2. `Dispatch Semaphore` 

   동일한 자원에 접근하는 것을 막기위한 세마포어
   현재 이슈에서도 세마포어 1개로 지정하고 wait, signal를 통해 순서를 보장할 수 있다.

   하지만 동일한 자원 접근이 아니므로 Custom Queue의 시리얼이 더 적합하다고 판단했다.

3. `Dispatch Group`

   연관된 작업을 그룹으로 묶어서 전체가 끝남을 알리거나 최대 얼마나 기다리게 데드라인을 정할 수 있다.
   현재 이슈에서 이미지 순서보장에서 적합하지 않다고 생각했다. 

   

```swift
let dispatchSerialQueue = DispatchQueue(label: "이미지 다운로드 시리얼 큐")
var images: [UIImage] = []
if imageURL.isEmpty { return }
DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
    for index in 0..<imageURL.count {
        guard let url = URL(string: imageURL[index]) else { return }
        dispatchSerialQueue.sync {
            if let image = try? Data(contentsOf: url) {
                DispatchQueue.main.async {
                    images.append(UIImage(data: image) ?? UIImage())
                        if images.count == imageURL.count {
                            self.itemImages = images
                        }
                    }
                }
            }
        }
    }
}
```

![스크린샷 2021-10-20 오전 1.01.28](https://raw.githubusercontent.com/Fezravien/UploadForMarkdown/forUpload/img/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202021-10-20%20%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%A5%E1%86%AB%201.01.28.png)

<br>

이제 여러번 동일한 동작을 해도 이미지가 올라오는 것을 확인할 수 있다.

<img src="https://user-images.githubusercontent.com/44525561/138393605-dbd67601-a9a2-4eba-b774-1b9b8aa0109f.gif" width="30%"> 

